### PR TITLE
Fixed hyperlink for IPs shown in IP ban list

### DIFF
--- a/banmanagement/searchip.php
+++ b/banmanagement/searchip.php
@@ -112,7 +112,7 @@ else {
 			
 			echo '
 				<tr'.(isset($f['past']) ? ' class="warning"' : '').'>
-					<td><a href="index.php?action=viewip&player='.$ip.'&server='.$_GET['server'].'">'.$ip.'</a></td>
+					<td><a href="index.php?action=viewip&ip='.$ip.'&server='.$_GET['server'].'">'.$ip.'</a></td>
 					<td>'.$f['type'].'</td>
 					<td>'.$f['by'].'</td>
 					<td>'.$f['reason'].'</td>


### PR DESCRIPTION
Simple correction for a typo in the generation of the hyperlink.

Without:
`index.php?action=viewip&player=2.103.174.209&server=0` (results in redirect to index.php)

With:
`index.php?action=viewip&ip=2.103.174.209&server=0` (correctly shows ban history etc for IP)

Example:
http://www.frostcast.net/banmanagement/index.php?action=searchip&server=0&player=%
Any of the IPs are effectively dead links.
