### PR TITLE
Prevent NPE on disable when the external database is not enabled

### DIFF
--- a/src/me/confuserr/banmanager/BanManager.java
+++ b/src/me/confuserr/banmanager/BanManager.java
@@ -78,7 +78,10 @@ public class BanManager extends JavaPlugin {
 
 		// Close the database connection
 		localConn.close();
-		extConn.close();
+
+		if(extConn != null) {
+			extConn.close();
+		}
 
 		getLogger().info("[BanManager] has been disabled");
 	}


### PR DESCRIPTION
Checks if extConn is null before attempting to close the connection.
