### PR TITLE
Fixes with firefox 23 related style issues

### DIFF
--- a/banmanagement/home.php
+++ b/banmanagement/home.php
@@ -161,8 +161,8 @@ function latestWarnings($server, $serverID) {
 				}
 				?>
 					<div class="btn-group">
-						<input type="submit" class="btn btn-primary" value="Search" />
-						<a href="#" class="btn btn-primary" id="viewall">Display All</a>
+						<button type="submit" class="btn btn-primary">Search</button>
+						<button type="button" class="btn btn-primary" id="viewall">Display All</button>
 					</div>
 					<?php
 					if(isset($settings['submit_buttons_after_html']))


### PR DESCRIPTION
Tested with chrome (latest/dev builds), firefox(latest), internet
explorer (9,10/latest). There's a bug with the search in Internet
Explorer 10, IE is a horrible browser and microsoft should doom it to
hell but because we live in this world, we developers must be abused by
IE's requirements.

The fix is the btn-group heights; firefox reduces the heights of input
fields.

I don't even want to investigate the problem with IE until I do an update to the tablesorter styles.
