### PR TITLE
Allow color codes for bold (&l)

### DIFF
--- a/src/me/confuserr/banmanager/Util.java
+++ b/src/me/confuserr/banmanager/Util.java
@@ -53,7 +53,7 @@ public class Util {
 	}
 
 	public static String colorize(String string) {
-		return string.replaceAll("(?i)&([a-k0-9])", "\u00A7$1");
+		return string.replaceAll("(?i)&([a-l0-9])", "\u00A7$1");
 	}
 
 	public static void sendMessage(CommandSender sender, String message) {


### PR DESCRIPTION
The color code for bold (&l) is not included in the regex. Changing a-k to a-l will allow it.
