### PR TITLE
Add ability to use bold color code (&l) in configuration

### DIFF
--- a/src/me/confuserr/banmanager/Util.java
+++ b/src/me/confuserr/banmanager/Util.java
@@ -53,7 +53,7 @@ public class Util {
 	}
 
 	public static String colorize(String string) {
-		return string.replaceAll("(?i)&([a-k0-9])", "\u00A7$1");
+		return string.replaceAll("(?i)&([a-l0-9])", "\u00A7$1");
 	}
 
 	public static void sendMessage(CommandSender sender, String message) {


### PR DESCRIPTION
Before, the regex allowed only codes a-k and 0-9. &l is a code that represents bolded text. By changing the regex to a-l0-9, the bold text is enabled in the configuration
