### PR TITLE
Fix for PHP session clash

### DIFF
--- a/banmanagement/index.php
+++ b/banmanagement/index.php
@@ -7,6 +7,7 @@
 	may be available at http://creativecommons.org/licenses/by-nc-sa/2.0/uk/.
 	Additional licence terms at https://raw.github.com/confuser/Ban-Management/master/banmanagement/licence.txt
 */
+session_name("BanManagement");
 session_start();
 ob_start();
 error_reporting(0); // Disable error reports for security


### PR DESCRIPTION
Quick fix for the PHP session clash that occasionally broke admin logins on the web interface. There should be no more conflicts, assuming no other PHP sessions on the web server are called 'BanManagement' (unlikely). Adds a few extra milliseconds to start-up, but fixes the issue (at least in my environment).
