### PR TITLE
Fix the lines of the Past Ban Stats with </br>

### DIFF
--- a/banmanagement/home.php
+++ b/banmanagement/home.php
@@ -154,7 +154,7 @@ function latestWarnings($server, $serverID) {
 							foreach($settings['servers'] as $server) {
 								list($pastBans) = cache("SELECT COUNT(*) FROM ".$server['recordTable'], 3600, '', $server, $server['name'].'pastBanStats');	
 
-								echo '<span>'.$pastBans.'</span> '. $language['pastbans_text'] .'';
+								echo '<span>'.$pastBans.'</span> '. $language['pastbans_text'] .' </br>';
 								}
 							?>
 						</p>


### PR DESCRIPTION
Fix the lines for the Past Ban Stats because it you have more at two servers banlist look like is all in one line and messy. So i add the br. XD

Exp before:
http://gyazo.com/138976339c6a1d404db92d842dee528b

Exp now:
http://gyazo.com/db7d86fe021a5d5793121b2d052862a0
