### PR TITLE
Use an alternate for Bukkit.broadcast(String message, String permission)

### DIFF
--- a/src/main/java/me/confuser/banmanager/commands/KickCommand.java
+++ b/src/main/java/me/confuser/banmanager/commands/KickCommand.java
@@ -108,7 +108,7 @@ public class KickCommand extends BukkitCommand<BanManager> {
       message.sendTo(sender);
     }
 
-    plugin.getServer().broadcast(message.toString(), "bm.notify.kick");
+    CommandUtils.broadcast(message.toString(), "bm.notify.kick");
 
     return true;
   }

--- a/src/main/java/me/confuser/banmanager/commands/LoglessKickCommand.java
+++ b/src/main/java/me/confuser/banmanager/commands/LoglessKickCommand.java
@@ -78,7 +78,7 @@ public class LoglessKickCommand extends BukkitCommand<BanManager> {
       message.sendTo(sender);
     }
 
-    plugin.getServer().broadcast(message.toString(), "bm.notify.kick");
+    CommandUtils.broadcast(message.toString(), "bm.notify.kick");
 
     return true;
   }

--- a/src/main/java/me/confuser/banmanager/commands/UnbanCommand.java
+++ b/src/main/java/me/confuser/banmanager/commands/UnbanCommand.java
@@ -107,7 +107,7 @@ public class UnbanCommand extends BukkitCommand<BanManager> implements TabComple
           message.sendTo(sender);
         }
 
-        plugin.getServer().broadcast(message.toString(), "bm.notify.unban");
+        CommandUtils.broadcast(message.toString(), "bm.notify.unban");
       }
 
     });

--- a/src/main/java/me/confuser/banmanager/commands/UnbanIpCommand.java
+++ b/src/main/java/me/confuser/banmanager/commands/UnbanIpCommand.java
@@ -102,7 +102,7 @@ public class UnbanIpCommand extends BukkitCommand<BanManager> {
           message.sendTo(sender);
         }
 
-        plugin.getServer().broadcast(message.toString(), "bm.notify.unbanip");
+        CommandUtils.broadcast(message.toString(), "bm.notify.unbanip");
       }
 
     });

--- a/src/main/java/me/confuser/banmanager/commands/UnmuteCommand.java
+++ b/src/main/java/me/confuser/banmanager/commands/UnmuteCommand.java
@@ -108,7 +108,7 @@ public class UnmuteCommand extends BukkitCommand<BanManager> implements TabCompl
           message.sendTo(sender);
         }
 
-        plugin.getServer().broadcast(message.toString(), "bm.notify.unmute");
+        CommandUtils.broadcast(message.toString(), "bm.notify.unmute");
       }
 
     });

--- a/src/main/java/me/confuser/banmanager/commands/WarnCommand.java
+++ b/src/main/java/me/confuser/banmanager/commands/WarnCommand.java
@@ -146,7 +146,7 @@ public class WarnCommand extends AutoCompleteNameTabCommand<BanManager> {
           message.sendTo(sender);
         }
 
-        plugin.getServer().broadcast(message.toString(), "bm.notify.warn");
+        CommandUtils.broadcast(message.toString(), "bm.notify.warn");
 
         final List<String> actionCommands;
 

--- a/src/main/java/me/confuser/banmanager/listeners/BanListener.java
+++ b/src/main/java/me/confuser/banmanager/listeners/BanListener.java
@@ -5,6 +5,7 @@ import me.confuser.banmanager.data.IpBanData;
 import me.confuser.banmanager.data.PlayerBanData;
 import me.confuser.banmanager.events.IpBanEvent;
 import me.confuser.banmanager.events.PlayerBanEvent;
+import me.confuser.banmanager.util.CommandUtils;
 import me.confuser.banmanager.util.DateUtils;
 import me.confuser.banmanager.util.IPUtils;
 import me.confuser.bukkitutil.Message;
@@ -34,7 +35,7 @@ public class BanListener extends Listeners<BanManager> {
     message.set("player", ban.getPlayer().getName()).set("actor", ban.getActor().getName())
            .set("reason", ban.getReason());
 
-    plugin.getServer().broadcast(message.toString(), broadcastPermission);
+    CommandUtils.broadcast(message.toString(), broadcastPermission);
 
     // Check if the sender is online and does not have the
     // broadcastPermission
@@ -67,7 +68,7 @@ public class BanListener extends Listeners<BanManager> {
     message.set("ip", IPUtils.toString(ban.getIp())).set("actor", ban.getActor().getName())
            .set("reason", ban.getReason());
 
-    plugin.getServer().broadcast(message.toString(), broadcastPermission);
+    CommandUtils.broadcast(message.toString(), broadcastPermission);
 
     // Check if the sender is online and does not have the
     // broadcastPermission

--- a/src/main/java/me/confuser/banmanager/listeners/JoinListener.java
+++ b/src/main/java/me/confuser/banmanager/listeners/JoinListener.java
@@ -3,6 +3,7 @@ package me.confuser.banmanager.listeners;
 import com.j256.ormlite.dao.CloseableIterator;
 import me.confuser.banmanager.BanManager;
 import me.confuser.banmanager.data.*;
+import me.confuser.banmanager.util.CommandUtils;
 import me.confuser.banmanager.util.DateUtils;
 import me.confuser.banmanager.util.IPUtils;
 import me.confuser.banmanager.util.UUIDUtils;
@@ -93,13 +94,13 @@ public class JoinListener extends Listeners<BanManager> {
   private void handleJoinDeny(PlayerData player, String reason) {
     Message message = Message.get("deniedNotify.player").set("player", player.getName()).set("reason", reason);
 
-    plugin.getServer().broadcast(message.toString(), "bm.notify.denied.player");
+    CommandUtils.broadcast(message.toString(), "bm.notify.denied.player");
   }
 
   private void handleJoinDeny(String ip, String reason) {
     Message message = Message.get("deniedNotify.ip").set("ip", ip).set("reason", reason);
 
-    plugin.getServer().broadcast(message.toString(), "bm.notify.denied.ip");
+    CommandUtils.broadcast(message.toString(), "bm.notify.denied.ip");
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -147,10 +148,10 @@ public class JoinListener extends Listeners<BanManager> {
                                    .set("player", onlinePlayer.getName())
                                    .toString();
 
-            plugin.getServer().broadcast(header, "bm.notify.notes.join");
+            CommandUtils.broadcast(header, "bm.notify.notes.join");
 
             for (String message : notes) {
-              plugin.getServer().broadcast(message, "bm.notify.notes.join");
+              CommandUtils.broadcast(message, "bm.notify.notes.join");
             }
 
           }
@@ -234,7 +235,7 @@ public class JoinListener extends Listeners<BanManager> {
         message.set("player", event.getPlayer().getName());
         message.set("players", sb.toString());
 
-        plugin.getServer().broadcast(message.toString(), "bm.notify.duplicateips");
+        CommandUtils.broadcast(message.toString(), "bm.notify.duplicateips");
       }
     }, 20L);
   }

--- a/src/main/java/me/confuser/banmanager/listeners/MuteListener.java
+++ b/src/main/java/me/confuser/banmanager/listeners/MuteListener.java
@@ -3,6 +3,7 @@ package me.confuser.banmanager.listeners;
 import me.confuser.banmanager.BanManager;
 import me.confuser.banmanager.data.PlayerMuteData;
 import me.confuser.banmanager.events.PlayerMuteEvent;
+import me.confuser.banmanager.util.CommandUtils;
 import me.confuser.banmanager.util.DateUtils;
 import me.confuser.bukkitutil.Message;
 import me.confuser.bukkitutil.listeners.Listeners;
@@ -31,7 +32,7 @@ public class MuteListener extends Listeners<BanManager> {
     message.set("player", mute.getPlayer().getName()).set("actor", mute.getActor().getName())
            .set("reason", mute.getReason());
 
-    plugin.getServer().broadcast(message.toString(), broadcastPermission);
+    CommandUtils.broadcast(message.toString(), broadcastPermission);
 
     // Check if the sender is online and does not have the
     // broadcastPermission

--- a/src/main/java/me/confuser/banmanager/listeners/NoteListener.java
+++ b/src/main/java/me/confuser/banmanager/listeners/NoteListener.java
@@ -3,6 +3,7 @@ package me.confuser.banmanager.listeners;
 import me.confuser.banmanager.BanManager;
 import me.confuser.banmanager.data.PlayerNoteData;
 import me.confuser.banmanager.events.PlayerNoteCreatedEvent;
+import me.confuser.banmanager.util.CommandUtils;
 import me.confuser.bukkitutil.Message;
 import me.confuser.bukkitutil.listeners.Listeners;
 import org.bukkit.entity.Player;
@@ -21,7 +22,7 @@ public class NoteListener extends Listeners<BanManager> {
            .set("actor", note.getActor().getName())
            .set("message", note.getMessage());
 
-    plugin.getServer().broadcast(message.toString(), "bm.notify.notes");
+    CommandUtils.broadcast(message.toString(), "bm.notify.notes");
 
     // Check if the sender is online and does not have the
     // broadcastPermission

--- a/src/main/java/me/confuser/banmanager/util/CommandUtils.java
+++ b/src/main/java/me/confuser/banmanager/util/CommandUtils.java
@@ -3,9 +3,11 @@ package me.confuser.banmanager.util;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
+import org.bukkit.permissions.Permissible;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class CommandUtils {
 
@@ -46,5 +48,15 @@ public class CommandUtils {
     }
 
     return str.split(delimiter);
+  }
+
+  public static void broadcast(String message, String permission) {
+    Set<Permissible> permissibles = Bukkit.getPluginManager().getPermissionSubscriptions("bukkit.broadcast.user");
+    for (Permissible permissible : permissibles) {
+      if (((permissible instanceof CommandSender)) && (permissible.hasPermission(permission))) {
+        CommandSender user = (CommandSender) permissible;
+        user.sendMessage(message);
+      }
+    }
   }
 }


### PR DESCRIPTION
Changed #226 to use the internal code of `Bukkit.broadcastMessage()` instead of looping through online players.  Solves the issue of broadcasts not reaching console.