### PR TITLE
Use SSL for safer downloads

### DIFF
--- a/src/main/resources/geoip.yml
+++ b/src/main/resources/geoip.yml
@@ -1,7 +1,7 @@
 enabled: false
 download:
-  city: 'http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz'
-  country: 'http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz'
+  city: 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz'
+  country: 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz'
   lastUpdated: 0
 # Allow only certain countries on the server
 countries:


### PR DESCRIPTION
Very small change, since the website has a SSL certificate why not use it? Encrypts data.