### PR TITLE
Highlight messages from muted players

### DIFF
--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -135,7 +135,7 @@ messages:
     player:
       blocked: '&cYou may not use the [command] command whilst muted!'
       disallowed: '&6You have been permanently muted for &4[reason] &6by [actor]'
-      broadcast: ''
+      broadcast: '&4[Muted]&r '
     notify: '&6[player] has been permanently muted by [actor] for &4[reason]'
     error:
       exists: '&c[player] is already muted'


### PR DESCRIPTION
Might be useful if team mate X mutes a player, team mate Y joins,  does not know that this particular player has been muted already, just noticing that he is writing stuff, but actually he is just TRYING to write stuff.