### PR TITLE
Multiaccount check

### DIFF
--- a/src/main/java/me/confuser/banmanager/configs/DefaultConfig.java
+++ b/src/main/java/me/confuser/banmanager/configs/DefaultConfig.java
@@ -55,6 +55,10 @@ public class DefaultConfig extends Config<BanManager> {
   @Getter
   private int maxOnlinePerIp = 0;
   @Getter
+  private int maxMultiaccountsRecently = 0;
+  @Getter
+  private long multiaccountsTime = 300L;
+  @Getter
   private HooksConfig hooksConfig;
   @Getter
   private boolean broadcastOnSync = false;
@@ -108,6 +112,8 @@ public class DefaultConfig extends Config<BanManager> {
     }
 
     maxOnlinePerIp = conf.getInt("maxOnlinePerIp", 0);
+    maxMultiaccountsRecently = conf.getInt("maxMultiaccountsRecently", 0);
+    multiaccountsTime = conf.getLong("multiaccountsTime", 300L);
 
     hooksConfig = new HooksConfig(conf.getConfigurationSection("hooks"));
 

--- a/src/main/java/me/confuser/banmanager/listeners/JoinListener.java
+++ b/src/main/java/me/confuser/banmanager/listeners/JoinListener.java
@@ -370,6 +370,19 @@ public class JoinListener extends Listeners<BanManager> {
       }
 
     }
+    
+    if (plugin.getConfiguration().getMaxMultiaccountsRecently() > 0) {
+      long ip = IPUtils.toLong(event.getAddress());
+      long timediff = plugin.getConfiguration().getMultiaccountsTime();
+
+      List<PlayerData> multiaccountPlayers = plugin.getPlayerStorage().getDuplicatesInTime(ip, timediff);
+
+      if (multiaccountPlayers.size() > plugin.getConfiguration().getMaxMultiaccountsRecently()) {
+        event.disallow(PlayerLoginEvent.Result.KICK_OTHER, Message.getString("deniedMultiaccounts"));
+        return;
+      }
+
+    }
 
     if (!plugin.getConfiguration().isDuplicateIpCheckEnabled()) {
       return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -167,6 +167,14 @@ cleanUp:
 # Maximum amount of players allowed from a single ip, set to 0 to disable
 maxOnlinePerIp: 0
 
+# Maximum amount of players allowed from a single ip (recently logged in), set to 0 to disable
+# The time interval to check is set with multiaccountsTime
+maxMultiaccountsRecently: 0
+
+# Time interval to look up for recently players (in seconds)
+# Used with maxMultiaccountsRecently > 0
+multiaccountsTime: 300
+
 # Whether to check the database to see if the player is banned on join or not
 # Recommended to be disabled, the schedule sync tasks should suffice
 checkOnJoin: false

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -12,6 +12,7 @@ messages:
     player: '&cWarning: [player] attempted to join the server but was denied due to &4[reason]'
     ip: '&cWarning: [ip] attempted to join the server but was denied due to &4[reason]'
   deniedMaxIp: '&cToo many players with your ip address online'
+  deniedMultiaccounts: '&cToo many players with your ip address logged in recently'
   deniedCountry: '&cYou may not connect from your region'
 
   time:


### PR DESCRIPTION
Hey,

This allows to deny accounts with the same ip within a configurable time interval. On our server, some players are joining with more than 20 accounts (leaked premium accounts). To ban the ip is one solution, but this multiaccount check will make it a bit difficulter to join with so many accounts within a few minutes (or a day if you wish so).

This is usable without one of the accounts being banned. It simply denys a **configurable amount of accounts** with the same ip in a **configurable time interval**.

I hope you'll find this as an enhancement and give it it try. I've sucessfully tested it on my testing server.