### PR TITLE
Fix list others reports permission

### DIFF
--- a/src/main/java/me/confuser/banmanager/commands/report/ListSubCommand.java
+++ b/src/main/java/me/confuser/banmanager/commands/report/ListSubCommand.java
@@ -57,7 +57,7 @@ public class ListSubCommand extends SubCommand<BanManager> {
         ReportList reports;
 
         try {
-          if (!(sender instanceof Player) || sender.hasPermission("bm.command.report.list.others")) {
+          if (!(sender instanceof Player) || sender.hasPermission("bm.command.reports.list.others")) {
             reports = plugin.getPlayerReportStorage().getReports(page, state, null);
           } else {
             reports = plugin.getPlayerReportStorage()


### PR DESCRIPTION
On the dev.bukkit command documentation page specified `bm.command.reports.list.others` permission.