### PR TITLE
feat: allow JSON messages

### DIFF
--- a/bukkit/src/main/java/me/confuser/banmanager/bukkit/BukkitPlayer.java
+++ b/bukkit/src/main/java/me/confuser/banmanager/bukkit/BukkitPlayer.java
@@ -9,6 +9,7 @@ import me.confuser.banmanager.common.util.Message;
 import me.confuser.banmanager.common.util.UUIDUtils;
 import net.kyori.text.TextComponent;
 import net.kyori.text.serializer.gson.GsonComponentSerializer;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -46,7 +47,11 @@ public class BukkitPlayer implements CommonPlayer {
   }
 
   public void sendMessage(String message) {
-    getPlayer().sendMessage(BukkitServer.formatMessage(message));
+    if(Message.isJSONMessage(message)) {
+      sendJSONMessage(message);
+    } else {
+      getPlayer().sendMessage(BukkitServer.formatMessage(message));
+    }
   }
 
   public void sendMessage(Message message) {
@@ -56,6 +61,11 @@ public class BukkitPlayer implements CommonPlayer {
   @Override
   public void sendJSONMessage(TextComponent jsonString) {
     getPlayer().spigot().sendMessage(ComponentSerializer.parse(GsonComponentSerializer.INSTANCE.serialize(jsonString)));
+  }
+
+  @Override
+  public void sendJSONMessage(String message) {
+    player.spigot().sendMessage(ComponentSerializer.parse(message));
   }
 
   public boolean isConsole() {

--- a/bukkit/src/main/java/me/confuser/banmanager/bukkit/BukkitPlayer.java
+++ b/bukkit/src/main/java/me/confuser/banmanager/bukkit/BukkitPlayer.java
@@ -65,7 +65,7 @@ public class BukkitPlayer implements CommonPlayer {
 
   @Override
   public void sendJSONMessage(String message) {
-    player.spigot().sendMessage(ComponentSerializer.parse(message));
+    getPlayer().spigot().sendMessage(ComponentSerializer.parse(message));
   }
 
   public boolean isConsole() {

--- a/bungee/src/main/java/me/confuser/banmanager/bungee/BungeePlayer.java
+++ b/bungee/src/main/java/me/confuser/banmanager/bungee/BungeePlayer.java
@@ -8,6 +8,7 @@ import me.confuser.banmanager.common.util.Message;
 import net.kyori.text.TextComponent;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.chat.ComponentSerializer;
 
 import java.net.InetAddress;
 import java.util.UUID;
@@ -28,7 +29,11 @@ public class BungeePlayer implements CommonPlayer {
 
   @Override
   public void sendMessage(String message) {
-    getPlayer().sendMessage(message);
+    if(Message.isJSONMessage(message)) {
+      sendJSONMessage(message);
+    } else {
+      getPlayer().sendMessage(message);
+    }
   }
 
   @Override
@@ -39,6 +44,11 @@ public class BungeePlayer implements CommonPlayer {
   @Override
   public void sendJSONMessage(TextComponent jsonString) {
     getPlayer().sendMessage(BungeeServer.formatMessage(jsonString));
+  }
+
+  @Override
+  public void sendJSONMessage(String jsonString) {
+    getPlayer().sendMessage(ComponentSerializer.parse(jsonString));
   }
 
   @Override

--- a/common/src/main/java/me/confuser/banmanager/common/CommonPlayer.java
+++ b/common/src/main/java/me/confuser/banmanager/common/CommonPlayer.java
@@ -18,6 +18,8 @@ public interface CommonPlayer extends CommonSender {
 
   void sendJSONMessage(TextComponent jsonString);
 
+  void sendJSONMessage(String jsonString);
+
   @Override
   boolean isConsole();
 

--- a/common/src/main/java/me/confuser/banmanager/common/util/Message.java
+++ b/common/src/main/java/me/confuser/banmanager/common/util/Message.java
@@ -106,6 +106,10 @@ public class Message {
     return true;
   }
 
+  public static boolean isJSONMessage(String message) {
+    return message.startsWith("{") && message.endsWith("}") || message.startsWith("[") && message.endsWith("]");
+  }
+
   @Override
   public String toString() {
     return message;

--- a/common/src/test/java/me/confuser/banmanager/common/TestPlayer.java
+++ b/common/src/test/java/me/confuser/banmanager/common/TestPlayer.java
@@ -36,6 +36,10 @@ public class TestPlayer implements CommonPlayer {
   }
 
   @Override
+  public void sendJSONMessage(String jsonString) {
+  }
+
+  @Override
   public boolean isConsole() {
     return false;
   }

--- a/sponge/src/main/java/me/confuser/banmanager/sponge/SpongePlayer.java
+++ b/sponge/src/main/java/me/confuser/banmanager/sponge/SpongePlayer.java
@@ -50,7 +50,11 @@ public class SpongePlayer implements CommonPlayer {
 
   @Override
   public void sendMessage(String message) {
-    getPlayer().sendMessage(SpongeServer.formatMessage(message));
+    if(Message.isJSONMessage(message)) {
+      sendJSONMessage(message);
+    } else {
+      getPlayer().sendMessage(SpongeServer.formatMessage(message));
+    }
   }
 
   @Override
@@ -61,6 +65,11 @@ public class SpongePlayer implements CommonPlayer {
   @Override
   public void sendJSONMessage(TextComponent jsonString) {
     getPlayer().sendMessage(TextSerializers.JSON.deserialize(GsonComponentSerializer.INSTANCE.serialize(jsonString)));
+  }
+
+  @Override
+  public void sendJSONMessage(String jsonString) {
+    getPlayer().sendMessage(TextSerializers.JSON.deserialize(jsonString));
   }
 
   @Override


### PR DESCRIPTION
Allows to use raw JSON in messages.yml
If receiver doesn't support JSON (console), it will get JSON as a plain text (although it's not a problem since BanManager uses different messages for console and players)
Message is considered to be a JSON message if it starts and ends like JSON object/array (i.e. { [ ] })