### PR TITLE
fix: always put player names into autoCompleteTree

### DIFF
--- a/common/src/test/java/me/confuser/banmanager/common/storage/PlayerStorageTest.java
+++ b/common/src/test/java/me/confuser/banmanager/common/storage/PlayerStorageTest.java
@@ -1,10 +1,14 @@
 package me.confuser.banmanager.common.storage;
 
+import com.j256.ormlite.dao.Dao.CreateOrUpdateStatus;
 import me.confuser.banmanager.common.BasePluginDbTest;
 import me.confuser.banmanager.common.data.PlayerData;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
 
 public class PlayerStorageTest extends BasePluginDbTest {
 
@@ -14,5 +18,25 @@ public class PlayerStorageTest extends BasePluginDbTest {
 
     assertEquals("Console", data.getName());
     assertEquals(plugin.getConsoleConfig().getUuid(), data.getUUID());
+  }
+
+  @Test
+  public void shouldUpsertPlayerData() throws SQLException {
+    PlayerStorage playerStorage = plugin.getPlayerStorage();
+
+    UUID uuid = UUID.randomUUID();
+
+    PlayerData data = new PlayerData(uuid, "Name 1");
+    CreateOrUpdateStatus status = playerStorage.upsert(data);
+    assertTrue(status.isCreated());
+    assertFalse(status.isUpdated());
+    assertNotNull(playerStorage.getAutoCompleteTree().getValueForExactKey("Name 1"));
+
+    data = new PlayerData(uuid, "Name 2");
+    status = playerStorage.upsert(data);
+    assertFalse(status.isCreated());
+    assertTrue(status.isUpdated());
+    assertNull(playerStorage.getAutoCompleteTree().getValueForExactKey("Name 1"));
+    assertNotNull(playerStorage.getAutoCompleteTree().getValueForExactKey("Name 2"));
   }
 }


### PR DESCRIPTION
Currently BM doesn't fill the autoCompleteTree with player names if database already has an associated record. It doesn't work correctly in multi-server setup.