### PR TITLE
fix: ignore cancelled AsyncPlayerPreLoginEvent events

### DIFF
--- a/bukkit/src/main/java/me/confuser/banmanager/bukkit/listeners/JoinListener.java
+++ b/bukkit/src/main/java/me/confuser/banmanager/bukkit/listeners/JoinListener.java
@@ -30,6 +30,10 @@ public class JoinListener implements Listener {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onJoin(AsyncPlayerPreLoginEvent event) {
+    if (event.getLoginResult() != AsyncPlayerPreLoginEvent.Result.ALLOWED) {
+      return;
+    }
+
     listener.onPreJoin(event.getUniqueId(), event.getName(), IPUtils.toIPAddress(event.getAddress()));
   }
 


### PR DESCRIPTION
Make it respect AsyncPlayerPreLoginEvent.Result and do not create a record in DB if login wasn't allowed