### PR TITLE
Try to interpret /bminfo arg as username before IP address

### DIFF
--- a/common/src/main/java/me/confuser/banmanager/common/commands/InfoCommand.java
+++ b/common/src/main/java/me/confuser/banmanager/common/commands/InfoCommand.java
@@ -83,7 +83,7 @@ public class InfoCommand extends CommonCommand {
           return;
         }
       } else {
-          sender.sendMessage("Fetching information by IP address is currently unsupported.");
+          sender.sendMessage(Message.getString("sender.error.ipNotSupported"));
       }
           /*
                        TODO

--- a/common/src/main/java/me/confuser/banmanager/common/commands/InfoCommand.java
+++ b/common/src/main/java/me/confuser/banmanager/common/commands/InfoCommand.java
@@ -43,9 +43,23 @@ public class InfoCommand extends CommonCommand {
     }
 
     final String search = parser.args.length > 0 ? parser.args[0] : sender.getName();
-    final boolean isName = !IPUtils.isValid(search);
 
-    if (isName && search.length() > 16) {
+    // validate username
+    boolean isName = (search.length() <= 16);
+    if (isName) {
+        for (char ch : search.toCharArray()) {
+            if (ch >= 'A' && ch <= 'Z') continue;
+            if (ch >= 'a' && ch <= 'z') continue;
+            if (ch >= '0' && ch <= '9') continue;
+            if (ch == '_') continue;
+            isName = false;
+            break;
+        }
+    }
+
+    final boolean isValidName = isName;
+
+    if (!isName && !IPUtils.isValid(search)) {
       sender.sendMessage(Message.getString("sender.error.invalidIp"));
       return true;
     }
@@ -60,7 +74,7 @@ public class InfoCommand extends CommonCommand {
     }
 
     getPlugin().getScheduler().runAsync(() -> {
-      if (isName) {
+      if (isValidName) {
         try {
           playerInfo(sender, search, index, parser);
         } catch (SQLException e) {
@@ -68,7 +82,10 @@ public class InfoCommand extends CommonCommand {
           e.printStackTrace();
           return;
         }
-      }/* else {
+      } else {
+          sender.sendMessage("Fetching information by IP address is currently unsupported.");
+      }
+          /*
                        TODO
                        ipInfo(sender, search);
                        }*/

--- a/common/src/main/resources/messages.yml
+++ b/common/src/main/resources/messages.yml
@@ -45,6 +45,7 @@ messages:
       noSelf: '&cYou cannot perform that action on yourself!'
       exception: '&cAn error occured whilst attempting to perform this command. Please check the console for further details.'
       invalidIp: '&cInvalid IP address, expecting w.x.y.z format'
+      ipNotSupported: '&cFetching information by IP address is currently unsupported.'
       offlinePermission: '&cYou are not allowed to perform this action on an offline player'
       exempt: '&c[player] is exempt from that action'
       noPermission: '&cYou do not have permission to perform that action'


### PR DESCRIPTION
Currently, `/bminfo` fails to provide any output at all when provided with a purely numeric username, e.g. `/bminfo 9081` gives no output. This is because such usernames are considered valid IP addresses by the `IPAddress` library. The current behavior of `/bminfo` is to first attempt to parse its target as an IP address, and then as a username. This PR reverses that behavior:
- We first check if the specified target is a valid username (it must be at most 16 characters and contain only numbers, letters, and underscores).
- If the target is not a valid username, then we attempt to validate it as an IP address and send an error message if validation fails.
- We are now guaranteed to have a valid username or IP address.

To verify that the problem is indeed the call to `IPUtils.isValid`, we can add the call `assertTrue(!IPUtils.isValid("9081"));` to `me.confuser.banmanager.common.util.IPUtilsTest`. The test then fails.