### PR TITLE
Fix: Use correct muteip disallowed message in default messages.yml

### DIFF
--- a/common/src/main/resources/messages.yml
+++ b/common/src/main/resources/messages.yml
@@ -172,7 +172,7 @@ messages:
 
   muteip:
     ip:
-      disallowed: '&6You have been banned from this server for &4[reason]'
+      disallowed: '&6You have been permanently muted for &4[reason] &6by [actor]'
       broadcast: '&4[Muted]&r [message]'
     notify: '&6[ip] ([players]) have been permanently muted by [actor] for &4[reason]'
     error:


### PR DESCRIPTION
Default disallowed message for muteip is currently `&6You have been banned from this server for &4[reason]` when it should be `&6You have been permanently muted for &4[reason] &6by [actor]`