### PR TITLE
fix: do not broadcast empty messages

### DIFF
--- a/bukkit/src/main/java/me/confuser/banmanager/bukkit/BukkitServer.java
+++ b/bukkit/src/main/java/me/confuser/banmanager/bukkit/BukkitServer.java
@@ -60,6 +60,8 @@ public class BukkitServer implements CommonServer {
 
   @Override
   public void broadcast(String message, String permission) {
+    if(message.isEmpty()) return;
+
     Set<Permissible> permissibles = Bukkit.getPluginManager().getPermissionSubscriptions("bukkit.broadcast.user");
 
     for (Permissible permissible : permissibles) {

--- a/bungee/src/main/java/me/confuser/banmanager/bungee/BungeeServer.java
+++ b/bungee/src/main/java/me/confuser/banmanager/bungee/BungeeServer.java
@@ -54,6 +54,8 @@ public class BungeeServer implements CommonServer {
 
   @Override
   public void broadcast(String message, String permission) {
+    if(message.isEmpty()) return;
+
     for (ProxiedPlayer player : ProxyServer.getInstance().getPlayers()) {
       if (player != null && player.hasPermission(permission)) {
         player.sendMessage(formatMessage(message));

--- a/sponge/src/main/java/me/confuser/banmanager/sponge/SpongeServer.java
+++ b/sponge/src/main/java/me/confuser/banmanager/sponge/SpongeServer.java
@@ -48,6 +48,8 @@ public class SpongeServer implements CommonServer {
 
   @Override
   public void broadcast(String message, String permission) {
+    if(message.isEmpty()) return;
+
     // @TODO can't figure out how to get message channels to work ¯\_(ツ)_/¯
     // MessageChannel.permission(permission).send(Sponge.getServer().getConsole(), Text.of(message));
     Arrays.stream(getOnlinePlayers()).forEach(player -> {


### PR DESCRIPTION
BanManager doesn't send empty messages to players.
This commit makes it also do not broadcast empty messages.