### PR TITLE
feat: allow disabling chat handling completely

### DIFF
--- a/bukkit/src/main/java/me/confuser/banmanager/bukkit/BMBukkitPlugin.java
+++ b/bukkit/src/main/java/me/confuser/banmanager/bukkit/BMBukkitPlugin.java
@@ -120,14 +120,17 @@ public class BMBukkitPlugin extends JavaPlugin {
     registerEvent(new CommandListener(plugin));
     registerEvent(new HookListener(plugin));
 
-    ChatListener chatListener = new ChatListener(plugin);
 
-    // Set custom priority
-    getServer().getPluginManager().registerEvent(AsyncPlayerChatEvent.class, chatListener, EventPriority.valueOf(plugin.getConfig().getChatPriority()),
+    String chatPriority = plugin.getConfig().getChatPriority();
+    if(!chatPriority.equals("NONE")) {
+      ChatListener chatListener = new ChatListener(plugin);
+      // Set custom priority
+      getServer().getPluginManager().registerEvent(AsyncPlayerChatEvent.class, chatListener, EventPriority.valueOf(chatPriority),
         (listener, event) -> {
           ((ChatListener) listener).onPlayerChat((AsyncPlayerChatEvent) event);
           ((ChatListener) listener).onIpChat((AsyncPlayerChatEvent) event);
         }, this);
+    }
 
     if (plugin.getConfig().isDisplayNotificationsEnabled()) {
       registerEvent(new BanListener(plugin));

--- a/bungee/src/main/java/me/confuser/banmanager/bungee/BMBungeePlugin.java
+++ b/bungee/src/main/java/me/confuser/banmanager/bungee/BMBungeePlugin.java
@@ -143,7 +143,10 @@ public class BMBungeePlugin extends Plugin {
     registerEvent(new JoinListener(this));
     registerEvent(new LeaveListener(plugin));
     registerEvent(new HookListener(plugin));
-    registerEvent(new ChatListener(plugin));
+
+    if (!plugin.getConfig().getChatPriority().equals("NONE")) {
+      registerEvent(new ChatListener(plugin));
+    }
 
     if (plugin.getConfig().isDisplayNotificationsEnabled()) {
       registerEvent(new BanListener(plugin));

--- a/sponge/src/main/java/me/confuser/banmanager/sponge/BMSpongePlugin.java
+++ b/sponge/src/main/java/me/confuser/banmanager/sponge/BMSpongePlugin.java
@@ -158,21 +158,24 @@ public class BMSpongePlugin {
     registerEvent(new CommandListener(plugin));
     registerEvent(new HookListener(plugin));
 
-    ChatListener chatListener = new ChatListener(plugin);
+    String chatPriority = plugin.getConfig().getChatPriority();
+    if(!chatPriority.equals("NONE")) {
+      ChatListener chatListener = new ChatListener(plugin);
 
-    // Map Bukkit EventPriority to Sponge Order
-    HashMap<String, Order> orders = new HashMap<String, Order>() {{
-      put("LOWEST", Order.FIRST);
-      put("LOW", Order.EARLY);
-      put("NORMAL", Order.DEFAULT);
-      put("HIGH", Order.LATE);
-      put("HIGHEST", Order.LATE);
-      put("MONITOR", Order.LAST);
-    }};
+      // Map Bukkit EventPriority to Sponge Order
+      HashMap<String, Order> orders = new HashMap<String, Order>() {{
+        put("LOWEST", Order.FIRST);
+        put("LOW", Order.EARLY);
+        put("NORMAL", Order.DEFAULT);
+        put("HIGH", Order.LATE);
+        put("HIGHEST", Order.LATE);
+        put("MONITOR", Order.LAST);
+      }};
 
-    Order priority = orders.getOrDefault(plugin.getConfig().getChatPriority(), Order.DEFAULT);
+      Order priority = orders.getOrDefault(chatPriority, Order.DEFAULT);
 
-    Sponge.getEventManager().registerListener(this, MessageChannelEvent.Chat.class, priority, chatListener);
+      Sponge.getEventManager().registerListener(this, MessageChannelEvent.Chat.class, priority, chatListener);
+    }
 
     if (plugin.getConfig().isDisplayNotificationsEnabled()) {
       registerEvent(new BanListener(plugin));


### PR DESCRIPTION
Allows setting NONE as 'chatPriority', effectively disabling mutes handling by BanManager. 
Useful when you use BanManager as a backend for your own mute handling system.