### PR TITLE
fix: safely handle duplicate entries when punishing alts

### DIFF
--- a/common/src/main/java/me/confuser/banmanager/common/listeners/CommonJoinListener.java
+++ b/common/src/main/java/me/confuser/banmanager/common/listeners/CommonJoinListener.java
@@ -13,6 +13,7 @@ import me.confuser.banmanager.common.util.*;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -541,7 +542,12 @@ public class CommonJoinListener {
             ban.isSilent(),
             ban.getExpires());
 
-        plugin.getPlayerBanStorage().ban(newBan);
+        try {
+            plugin.getPlayerBanStorage().ban(newBan);
+        } catch (SQLIntegrityConstraintViolationException e) {
+          // Ignore duplicate entry errors
+          plugin.getPlayerBanStorage().addBan(newBan);
+        }
 
         plugin.getScheduler().runSync(() -> {
           CommonPlayer bukkitPlayer = plugin.getServer().getPlayer(newBan.getPlayer().getUUID());
@@ -575,7 +581,12 @@ public class CommonJoinListener {
             mute.isSoft(),
             mute.getExpires());
 
-        plugin.getPlayerMuteStorage().mute(newMute);
+        try {
+          plugin.getPlayerMuteStorage().mute(newMute);
+        } catch (SQLIntegrityConstraintViolationException e) {
+          // Ignore duplicate entry errors
+          plugin.getPlayerMuteStorage().addMute(newMute);
+        }
       }
     }
   }


### PR DESCRIPTION
Reported on Discord:

>[<t:1724562463:T> INFO] player1 lost connection: Disconnected
[<t:1724562463:T> INFO] Warning: player1 has the same IP as the following players:
player2
[<t:1724562463:T> WARN] java.sql.SQLException: Unable to run insert stmt on object me.confuser.banmanager.common.data.PlayerBanData@59b3f364: INSERT INTO \`bm\_player\_bans\` (\`player\_id\` ,\`reason\` ,\`actor\_id\` ,\`created\` ,\`updated\` ,\`expires\` ,\`silent\` ) VALUES (?,?,?,?,?,?,?)
[<t:1724562463:T> WARN] at BanManagerBukkit.jar//me.confuser.banmanager.common.ormlite.misc.SqlExceptionUtil.create(SqlExceptionUtil.java:25)
[<t:1724562463:T> WARN] at BanManagerBukkit.jar//me.confuser.banmanager.common.ormlite.stmt.mapped.MappedCreate.insert(MappedCreate.java:138)
[<t:1724562463:T> WARN] at BanManagerBukkit.jar//me.confuser.banmanager.common.ormlite.stmt.StatementExecutor.create(StatementExecutor.java:458)
[<t:1724562463:T> WARN] at BanManagerBukkit.jar//me.confuser.banmanager.common.ormlite.dao.BaseDaoImpl.create(BaseDaoImpl.java:329)
[<t:1724562463:T> WARN] at BanManagerBukkit.jar//me.confuser.banmanager.common.storage.PlayerBanStorage.ban(PlayerBanStorage.java:206)
[<t:1724562463:T> WARN] at BanManagerBukkit.jar//me.confuser.banmanager.common.listeners.CommonJoinListener.punishAlts(CommonJoinListener.java:544)
[<t:1724562463:T> WARN] at BanManagerBukkit.jar//me.confuser.banmanager.common.listeners.CommonJoinListener.lambda$onPlayerLogin$1(CommonJoinListener.java:409)
[<t:1724562463:T> WARN] at org.bukkit.craftbukkit.v1\_19\_R2.scheduler.CraftTask.run(CraftTask.java:101)
[<t:1724562463:T> WARN] at org.bukkit.craftbukkit.v1\_19\_R2.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57)
[<t:1724562463:T> WARN] at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22)
[<t:1724562463:T> WARN] at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)

Issue is caused by punishAlts being triggered both on BungeeCord and Bukkit