### PR TITLE
feat: added pointsTimeframe to warningActions

### DIFF
--- a/common/src/main/java/me/confuser/banmanager/common/commands/TempWarnCommand.java
+++ b/common/src/main/java/me/confuser/banmanager/common/commands/TempWarnCommand.java
@@ -176,8 +176,7 @@ public class TempWarnCommand extends CommonCommand {
       final List<ActionCommand> actionCommands;
 
       try {
-        actionCommands = getPlugin().getConfig().getWarningActions()
-                                    .getCommand((int) getPlugin().getPlayerWarnStorage().getPointsCount(player));
+        actionCommands = getPlugin().getConfig().getWarningActions().getCommands(player, getPlugin().getPlayerWarnStorage().getPointsCount(player));
       } catch (SQLException e) {
         e.printStackTrace();
         return;

--- a/common/src/main/java/me/confuser/banmanager/common/commands/WarnCommand.java
+++ b/common/src/main/java/me/confuser/banmanager/common/commands/WarnCommand.java
@@ -155,8 +155,7 @@ public class WarnCommand extends CommonCommand {
       final List<ActionCommand> actionCommands;
 
       try {
-        actionCommands = getPlugin().getConfig().getWarningActions()
-            .getCommand(getPlugin().getPlayerWarnStorage().getPointsCount(player));
+        actionCommands = getPlugin().getConfig().getWarningActions().getCommands(player, getPlugin().getPlayerWarnStorage().getPointsCount(player));
       } catch (SQLException e) {
         e.printStackTrace();
         return;

--- a/common/src/main/java/me/confuser/banmanager/common/configs/ActionCommand.java
+++ b/common/src/main/java/me/confuser/banmanager/common/configs/ActionCommand.java
@@ -8,9 +8,12 @@ public class ActionCommand {
   private final String command;
   @Getter
   private final long delay;
+  @Getter
+  private final String pointsTimeframe;
 
-  public ActionCommand(String command, long delay) {
+  public ActionCommand(String command, long delay, String pointsTimeframe) {
     this.command = command;
     this.delay = delay;
+    this.pointsTimeframe = pointsTimeframe;
   }
 }

--- a/common/src/main/java/me/confuser/banmanager/common/configs/HooksConfig.java
+++ b/common/src/main/java/me/confuser/banmanager/common/configs/HooksConfig.java
@@ -92,7 +92,7 @@ public class HooksConfig {
         delay = delay * 20L; // Convert from seconds to ticks
       }
 
-      actionCommands.add(new ActionCommand((String) map.get("cmd"), delay));
+      actionCommands.add(new ActionCommand((String) map.get("cmd"), delay, ""));
     }
 
     return actionCommands;

--- a/common/src/main/java/me/confuser/banmanager/common/storage/PlayerWarnStorage.java
+++ b/common/src/main/java/me/confuser/banmanager/common/storage/PlayerWarnStorage.java
@@ -143,6 +143,25 @@ public class PlayerWarnStorage extends BaseDaoImpl<PlayerWarnData, Integer> {
     return 0;
   }
 
+  public double getPointsCount(PlayerData player, long timeframe) throws SQLException {
+    try (DatabaseConnection connection = connectionSource.getReadOnlyConnection(getTableName())) {
+      CompiledStatement statement = connection
+          .compileStatement("SELECT SUM(points) AS points FROM " + getTableName() + " WHERE player_id = ? AND created >= ?", StatementBuilder.StatementType.SELECT, null, DatabaseConnection
+              .DEFAULT_RESULT_FLAGS, false);
+
+      statement.setObject(0, player.getId(), SqlType.BYTE_ARRAY);
+      statement.setObject(1, timeframe, SqlType.LONG);
+
+      DatabaseResults results = statement.runQuery(null);
+
+      if (results.next()) return results.getDouble(0);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return 0;
+  }
+
   public boolean isRecentlyWarned(PlayerData player, long cooldown) throws SQLException {
     if (cooldown == 0) {
       return false;

--- a/common/src/test/java/me/confuser/banmanager/common/commands/WarnCommandTest.java
+++ b/common/src/test/java/me/confuser/banmanager/common/commands/WarnCommandTest.java
@@ -1,0 +1,144 @@
+package me.confuser.banmanager.common.commands;
+
+import me.confuser.banmanager.common.BasePluginDbTest;
+import me.confuser.banmanager.common.CommonPlayer;
+import me.confuser.banmanager.common.CommonServer;
+import me.confuser.banmanager.common.configs.ActionCommand;
+import me.confuser.banmanager.common.configs.WarningActionsConfig;
+import me.confuser.banmanager.common.data.PlayerData;
+import me.confuser.banmanager.common.data.PlayerWarnData;
+import me.confuser.banmanager.common.util.DateUtils;
+import me.confuser.banmanager.common.util.parsers.WarnCommandParser;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.*;
+import static org.awaitility.Awaitility.await;
+import java.lang.reflect.Field;
+
+public class WarnCommandTest extends BasePluginDbTest {
+  private WarnCommand cmd;
+
+  @Before
+  public void setupCmd() {
+    for (CommonCommand cmd : plugin.getCommands()) {
+      if (cmd.getCommandName().equals("warn")) {
+        this.cmd = (WarnCommand) cmd;
+        break;
+      }
+    }
+  }
+
+  @Test
+  public void shouldFailIfNoSilentPermission() {
+    CommonSender sender = spy(plugin.getServer().getConsoleSender());
+    String[] args = new String[]{"-s", "confuser", "test"};
+
+    when(sender.hasPermission(cmd.getPermission() + ".silent")).thenReturn(false);
+
+    assert (cmd.onCommand(sender, new WarnCommandParser(plugin, args, 1)));
+    verify(sender).sendMessage("&cYou do not have permission to perform that action");
+  }
+
+  @Test
+  public void shouldFailIfNoPointsPermission() {
+    CommonSender sender = spy(plugin.getServer().getConsoleSender());
+    String[] args = new String[]{"-p", "5", "confuser", "test"};
+
+    when(sender.hasPermission(cmd.getPermission() + ".points")).thenReturn(false);
+
+    assert (cmd.onCommand(sender, new WarnCommandParser(plugin, args, 1)));
+    verify(sender).sendMessage("&cYou do not have permission to perform that action");
+  }
+
+  @Test
+  public void shouldFailIfSelfWarn() {
+    CommonSender sender = spy(plugin.getServer().getConsoleSender());
+    String[] args = new String[]{"Console", "test"};
+
+    assert (cmd.onCommand(sender, new WarnCommandParser(plugin, args, 1)));
+    verify(sender).sendMessage("&cYou cannot perform that action on yourself!");
+  }
+
+  @Test
+  public void shouldFailIfOffline() {
+    CommonSender sender = spy(plugin.getServer().getConsoleSender());
+    String[] args = new String[]{testUtils.createRandomPlayerName(), "test"};
+
+    when(sender.hasPermission("bm.command.warn.offline")).thenReturn(false);
+
+    assert (cmd.onCommand(sender, new WarnCommandParser(plugin, args, 1)));
+    verify(sender).sendMessage("&cYou are not allowed to perform this action on an offline player");
+  }
+
+  @Test
+  public void shouldFailIfPlayerExempt() {
+    CommonSender sender = spy(plugin.getServer().getConsoleSender());
+    PlayerData player = testUtils.createRandomPlayer();
+    CommonPlayer commonPlayer = spy(server.getPlayer(player.getName()));
+    String[] args = new String[]{player.getName(), "test"};
+
+    when(sender.hasPermission("bm.exempt.override.warn")).thenReturn(false);
+    when(commonPlayer.hasPermission("bm.exempt.warn")).thenReturn(true);
+
+    assert (cmd.onCommand(sender, new WarnCommandParser(plugin, args, 1)));
+    verify(sender).sendMessage("&c" + player.getName() + " is exempt from that action");
+  }
+
+  @Test
+  public void shouldWarnPlayer() throws SQLException {
+    PlayerData player = testUtils.createRandomPlayer();
+    CommonServer server = spy(plugin.getServer());
+    CommonSender sender = spy(server.getConsoleSender());
+    String[] args = new String[]{player.getName(), "test"};
+
+    assert (cmd.onCommand(sender, new WarnCommandParser(plugin, args, 1)));
+
+    await().until(() -> plugin.getPlayerWarnStorage().getCount(player) == 1);
+    PlayerWarnData data = plugin.getPlayerWarnStorage().getWarnings(player).next();
+
+    assertEquals(player.getName(), data.getPlayer().getName());
+    assertEquals("test", data.getReason());
+    assertEquals(sender.getName(), data.getActor().getName());
+  }
+
+  @Test
+  public void shouldTriggerPointsTimeframeWarningActions() throws Exception {
+    CommonSender sender = spy(plugin.getServer().getConsoleSender());
+    PlayerData player = testUtils.createRandomPlayer();
+
+    ActionCommand commandWithTimeframe = new ActionCommand("kick", 0, "5m");
+    ActionCommand commandWithoutTimeframe = new ActionCommand("ban", 0, "");
+    ActionCommand commandWithOldTimeframe = new ActionCommand("kick", 0, "30d");
+    WarningActionsConfig warningActionsConfig = spy(plugin.getConfig().getWarningActions());
+
+    plugin.getPlayerWarnStorage().addWarning(new PlayerWarnData(player, sender.getData(), "testing", false, 0, DateUtils.parseDateDiff("31d", false)), false);
+    plugin.getPlayerWarnStorage().addWarning(new PlayerWarnData(player, sender.getData(), "testing", false, 0, DateUtils.parseDateDiff("1m", false)), false);
+
+    await().until(() -> plugin.getPlayerWarnStorage().getCount(player) == 2);
+
+    HashMap<Double, List<ActionCommand>> actions = new HashMap<>();
+    actions.put(1.0, Arrays.asList(commandWithoutTimeframe, commandWithTimeframe, commandWithOldTimeframe));
+
+    Field actionsField = WarningActionsConfig.class.getDeclaredField("actions");
+    actionsField.setAccessible(true);
+    actionsField.set(warningActionsConfig, actions);
+
+    List<ActionCommand> commands = warningActionsConfig.getCommands(player, 5);
+
+    assertEquals(2, commands.size());
+
+    assertTrue(commands.contains(commandWithTimeframe));
+    assertTrue(commands.contains(commandWithOldTimeframe));
+    assertFalse(commands.contains(commandWithoutTimeframe));
+  }
+}


### PR DESCRIPTION
this enables triggering commands only if the total accumulated points within the timeframe is reached

e.g. for a point value of 5, setting the timeframe to 30d will mean the command will only be executed if within the last 30 days the total number of points reached by the player is also 5

fixes #982