### PR TITLE
feat: add velocity config option to enable mutes

### DIFF
--- a/common/src/main/resources/velocity.yml
+++ b/common/src/main/resources/velocity.yml
@@ -1,2 +1,3 @@
 features:
   commands: true
+  force-enable-mute: false

--- a/common/src/main/resources/velocity.yml
+++ b/common/src/main/resources/velocity.yml
@@ -1,3 +1,3 @@
 features:
   commands: true
-  force-enable-mute: false
+  forceEnableMute: false

--- a/velocity/src/main/java/me.confuser.banmanager.velocity/BMVelocityPlugin.java
+++ b/velocity/src/main/java/me.confuser.banmanager.velocity/BMVelocityPlugin.java
@@ -134,6 +134,7 @@ public class BMVelocityPlugin {
       if (buildVersion <= 140) isMuteAllowed = true;
     }
     if (server.getPluginManager().getPlugin("signedvelocity").isPresent() && buildVersion >= 235) isMuteAllowed = true;
+    if (velocityConfig.isForceEnableMute()) isMuteAllowed = true;
   }
 
   private void setupCommands() {

--- a/velocity/src/main/java/me.confuser.banmanager.velocity/configs/VelocityConfig.java
+++ b/velocity/src/main/java/me.confuser.banmanager.velocity/configs/VelocityConfig.java
@@ -20,7 +20,7 @@ public class VelocityConfig extends Config {
   @Override
   public void afterLoad() {
     commandsEnabled = conf.getBoolean("features.commands", false);
-    forceEnableMute = conf.getBoolean("features.force-enable-mute", false);
+    forceEnableMute = conf.getBoolean("features.forceEnableMute", false);
   }
 
   @Override

--- a/velocity/src/main/java/me.confuser.banmanager.velocity/configs/VelocityConfig.java
+++ b/velocity/src/main/java/me.confuser.banmanager.velocity/configs/VelocityConfig.java
@@ -10,6 +10,8 @@ import java.nio.file.Path;
 public class VelocityConfig extends Config {
   @Getter
   private boolean commandsEnabled = false;
+  @Getter
+  private boolean forceEnableMute = false;
 
   public VelocityConfig(File dataFolder, CommonLogger logger) {
     super(dataFolder, "velocity.yml", logger);
@@ -18,6 +20,7 @@ public class VelocityConfig extends Config {
   @Override
   public void afterLoad() {
     commandsEnabled = conf.getBoolean("features.commands", false);
+    forceEnableMute = conf.getBoolean("features.force-enable-mute", false);
   }
 
   @Override


### PR DESCRIPTION
As it stands right now muting is only enabled if signedvelocity is present (or the velocity version is old enough). This adds a config option to override that behaviour.

This is useful if you have an alternative plugin to signedvelocity or are using a velocity fork that allows for chat cancelling.

This is just the simplest implementation I could think of, I am open to feedback if you think something should be done differently. 