### PR TITLE
fix: Allow for custom Velocity builds

### DIFF
--- a/velocity/src/main/java/me.confuser.banmanager.velocity/BMVelocityPlugin.java
+++ b/velocity/src/main/java/me.confuser.banmanager.velocity/BMVelocityPlugin.java
@@ -130,8 +130,12 @@ public class BMVelocityPlugin {
     int buildVersion = 0;
     if (maxVersionStringLength > 4) {
       String versionAsString = this.server.getVersion().getVersion().substring(maxVersionStringLength - 4, maxVersionStringLength - 1);
-      buildVersion = Integer.parseInt(versionAsString);
-      if (buildVersion <= 140) isMuteAllowed = true;
+      try{
+        buildVersion = Integer.parseInt(versionAsString);
+        if (buildVersion <= 140) isMuteAllowed = true;
+        } catch (NumberFormatException e) {
+          // Don't crash the plugin
+        }
     }
     if (server.getPluginManager().getPlugin("signedvelocity").isPresent() && buildVersion >= 235) isMuteAllowed = true;
     if (velocityConfig.isForceEnableMute()) isMuteAllowed = true;


### PR DESCRIPTION
Any velocity build with SNAPSHOT, or any other name that does not fit the official release naming scheme will crash the plugin on startup with velocity. This change allows it to fail silently, since the only reason it is checking is for builds that don't require chat signing.