### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * 0" # weekly
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BanManagement/BanManager/security/code-scanning/2](https://github.com/BanManagement/BanManager/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal access needed. Since this workflow checks out code and runs Gradle builds but does not interact with pull requests, issues, or push changes, `contents: read` is sufficient for the job (or at the workflow root).

The best, least-invasive fix in this snippet is to add a top-level `permissions:` block after the `on:` section. This will apply to all jobs in the workflow (currently just `build`) and ensures that the `GITHUB_TOKEN` only has read access to repository contents. No functional behavior of the build or publishing steps should change, as they rely on external secrets rather than write access to the repository via `GITHUB_TOKEN`.

Concretely, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (line 3–9) and the `jobs:` block (line 11). No imports or additional methods are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
