### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,8 @@
 name: E2E Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BanManagement/BanManager/security/code-scanning/1](https://github.com/BanManagement/BanManager/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the specific job, reducing the `GITHUB_TOKEN` privileges to the minimum required (at least `contents: read` for `actions/checkout`). Since this workflow has a single job (`e2e`) and nothing suggests it needs to write to the repository or manage issues/PRs, adding `permissions: contents: read` at the workflow root is sufficient and keeps the configuration simple.

Concretely, in `.github/workflows/e2e.yml`, add a root-level `permissions` section after the `name:` (before `on:`) to apply to all jobs. The block should specify `contents: read` as recommended by CodeQL. None of the steps use APIs that require additional token scopes such as `pull-requests: write` or `issues: write`, and artifact upload does not require explicit extra scopes beyond what GitHub grants for that operation, so no further permissions are needed. No imports or additional definitions are required; the change is purely to the YAML workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
