### PR TITLE
fix: include Fabric 1.21.11 in release + Modrinth publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,7 @@ jobs:
             release-jars/BanManagerFabric-mc1.20.1.jar
             release-jars/BanManagerFabric-mc1.21.1.jar
             release-jars/BanManagerFabric-mc1.21.4.jar
+            release-jars/BanManagerFabric-mc1.21.11.jar
           name: "BanManager v${{ needs.download-assets.outputs.version }}"
           version: ${{ needs.download-assets.outputs.version }}
           version-type: release
@@ -81,6 +82,7 @@ jobs:
             1.20.1
             1.21.1
             1.21.4
+            1.21.11
           game-version-filter: releases
           dependencies: |
             fabric-api@* (required)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Build all Fabric versions
       - name: Build all Fabric versions
-        run: ./gradlew :fabric:1.20.1:remapJar :fabric:1.21.1:remapJar :fabric:1.21.4:remapJar --build-cache
+        run: ./gradlew :fabric:1.20.1:remapJar :fabric:1.21.1:remapJar :fabric:1.21.4:remapJar :fabric:1.21.11:remapJar --build-cache
 
       # Build both Sponge modules (legacy API 7 and modern API 11+)
       - name: Build Sponge modules
@@ -77,6 +77,7 @@ jobs:
             [Download Fabric 1.20.1](https://github.com/BanManagement/BanManager/releases/download/v${{ steps.version.outputs.VERSION }}/BanManagerFabric-mc1.20.1.jar)
             [Download Fabric 1.21.1](https://github.com/BanManagement/BanManager/releases/download/v${{ steps.version.outputs.VERSION }}/BanManagerFabric-mc1.21.1.jar)
             [Download Fabric 1.21.4](https://github.com/BanManagement/BanManager/releases/download/v${{ steps.version.outputs.VERSION }}/BanManagerFabric-mc1.21.4.jar)
+            [Download Fabric 1.21.11](https://github.com/BanManagement/BanManager/releases/download/v${{ steps.version.outputs.VERSION }}/BanManagerFabric-mc1.21.11.jar)
           files: |
             bukkit/build/libs/BanManagerBukkit.jar
             bungee/build/libs/BanManagerBungeeCord.jar
@@ -86,3 +87,4 @@ jobs:
             fabric/versions/1.20.1/build/libs/BanManagerFabric-mc1.20.1.jar
             fabric/versions/1.21.1/build/libs/BanManagerFabric-mc1.21.1.jar
             fabric/versions/1.21.4/build/libs/BanManagerFabric-mc1.21.4.jar
+            fabric/versions/1.21.11/build/libs/BanManagerFabric-mc1.21.11.jar


### PR DESCRIPTION
## Summary

Fabric 1.21.11 support was added in #1040 and registered in `settings.gradle.kts`, but neither `release.yml` nor `publish.yml` were updated to build/distribute the jar. As a result, no `BanManagerFabric-mc1.21.11.jar` would ship from the release pipeline.

## Changes

- **release.yml**:
  - Add `:fabric:1.21.11:remapJar` to the Fabric build step
  - Add the download link in the GitHub release body template
  - Add the jar path to the release artefacts list
- **publish.yml** (Modrinth):
  - Include `BanManagerFabric-mc1.21.11.jar` in the files list
  - Add `1.21.11` to the Modrinth game-versions list

CurseForge publishing is intentionally unchanged: it ships only the Bukkit jar and its game-version list is maintained separately (a pre-existing concern beyond the scope of this PR).

## Test plan

- [ ] CI builds successfully on this branch
- [ ] Once merged, the next tag push will produce a draft release with all 9 jars (5 platform + 4 Fabric)

## Why now

This is a pre-flight fix for the upcoming v7.11.0 release, which lists Fabric 1.21.11 as a headline feature.