### PR TITLE
chore: prepare for next release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=me.confuser.banmanager
-version=7.11.0-SNAPSHOT
+version=8.0.0-SNAPSHOT
 org.gradle.parallel=true
 description="The defacto plugin for Minecraft to manage punishments and moderate more effectively"
 


### PR DESCRIPTION
## Summary

Bumps master from `7.11.0-SNAPSHOT` directly to `8.0.0-SNAPSHOT`.

Master never sits at `7.11.0` — that version exists only on the long-lived `release/v7` maintenance branch (which was just cut and tagged `v7.11.0`). Master jumps straight to v8 because the next release shipped from master will be `8.0.0` via the `feat/v8-minimessage-migration` branch (MiniMessage, Adventure 4.21.0, Component-first API, hybrid localisation, Java 17 minimum).

## Branch model after this lands

- `master` → `8.0.0-SNAPSHOT` (active development; `feat/v8-minimessage-migration` will fast-forward in)
- `release/v7` → `7.11.1-SNAPSHOT` (maintenance only; future patches via cherry-pick or direct PRs)

## Test plan

- [x] `gradle.properties` updated, no other changes
- [ ] CI green