### PR TITLE
ci: extend Java CI / E2E / CodeQL / Maven publish triggers to release/v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - release/v7
   schedule:
     - cron: "0 0 * * 0" # weekly
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "release/v7"]
   pull_request:
-    branches: ["master"]
+    branches: ["master", "release/v7"]
   schedule:
     - cron: "0 0 * * 0" # weekly
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - master
+      - release/v7
   workflow_dispatch: # Allow manual triggering
 
 jobs:

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Java CI", "E2E Tests"]
     types: [completed]
-    branches: [master]
+    branches: [master, release/v7]
 
 permissions:
   contents: read
@@ -18,10 +18,10 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Only consider successful completions on master from push events
+    # Only consider successful completions on master / release branches from push events
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'master' &&
+      (github.event.workflow_run.head_branch == 'master' || github.event.workflow_run.head_branch == 'release/v7') &&
       github.event.workflow_run.event == 'push'
 
     steps:


### PR DESCRIPTION
## Summary

Mirrors the same trigger update already pushed to `release/v7` (see commit c82d3c87 on that branch). Without this, `publish-maven.yml` would reject any v7.x release because the gate uses the default-branch (master) version of the workflow file and currently hardcodes `master`.

- `build.yml`, `e2e.yml`, `codeql.yml`: add `release/v7` to push branch list (PR triggers were already unconditional)
- `publish-maven.yml`: add `release/v7` to `workflow_run.branches` and the gate `if:` condition so that pushes to `release/v7` (e.g. v7.x bug-fix releases) trigger Maven Central publication

This is a follow-up to the v7/v8 split. v8 (master) and v7 (release/v7) now both publish Maven artifacts on push.

## Test plan
- [x] `release/v7` already carries the matching change (c82d3c87)
- [ ] Once merged, a push to `release/v7` should trigger Java CI + E2E and on success kick off `Publish to Maven Central`